### PR TITLE
Rename digipolisgent-ci

### DIFF
--- a/openshift/openshift-build.yml
+++ b/openshift/openshift-build.yml
@@ -60,7 +60,7 @@ objects:
           ref: "master"
           uri: ${GITURI}
         sourceSecret:
-          name: digipolisgent-ci
+          name: district09-ci
         type: Git
       strategy:
         sourceStrategy:


### PR DESCRIPTION
Service Factory - Gebruikersomgeving Vorige week werd een oude CI-account inactief gezet in Openshift. Als je ergens in de build templates verwijst naar het pullSecret met naam "digipolisgent-ci" pas je dit best aan naar "district09-ci". Hierdoor zullen al uw builds blijven werken. 